### PR TITLE
Fix iOS settings incorrect during build

### DIFF
--- a/Assets/UniversalSDK/Editor/UniversalSDKSettingsEditor.cs
+++ b/Assets/UniversalSDK/Editor/UniversalSDKSettingsEditor.cs
@@ -21,40 +21,37 @@ namespace Universal.UniversalSDK.Editor
 
         const string UnityAssetFolder = "Assets";
         
+        public static void EnsureFolderPathExists(string path)
+        {
+            string[] folders = path.Split(new char[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+            string currentPath = "";
+
+            for (int i = 0; i < folders.Length; i++)
+            {
+                currentPath = Path.Combine(currentPath, folders[i]);
+                if (!AssetDatabase.IsValidFolder(currentPath))
+                {
+                    string parentFolder = Path.GetDirectoryName(currentPath);
+                    string newFolder = Path.GetFileName(currentPath);
+                    AssetDatabase.CreateFolder(parentFolder, newFolder);
+                    
+                    // needs to be called so the folder is known to the database
+                    AssetDatabase.Refresh();
+                }
+            }
+        }
+
         public static UniversalSDKSettings GetOrCreateSettingsAsset()
         {
-            // Construct the full path to the settings asset.
-            string fullPath = Path.Combine(UnityAssetFolder, "Editor", "Resources", UniversalSDKSettings.settingsPath, 
+            var fullPath = Path.Combine(UnityAssetFolder, UniversalSDKSettings.settingsPath, 
                 UniversalSDKSettings.settingsAssetName + UniversalSDKSettings.settingsAssetExtension);
-
-            // Try to load the settings asset.
-            UniversalSDKSettings instance = AssetDatabase.LoadAssetAtPath<UniversalSDKSettings>(fullPath);
-
-            // If the asset doesn't exist, create it.
+            
+            EnsureFolderPathExists(Path.GetDirectoryName(fullPath));
+            
+            var instance = AssetDatabase.LoadAssetAtPath<UniversalSDKSettings>(fullPath);
+            
             if (instance == null)
             {
-                // Ensure the Editor folder exists.
-                string editorFolderPath = Path.Combine(UnityAssetFolder, "Editor");
-                if (!Directory.Exists(editorFolderPath))
-                {
-                    AssetDatabase.CreateFolder(UnityAssetFolder, "Editor");
-                }
-
-                // Ensure the Resources folder exists within the Editor folder.
-                string resourcesFolderPath = Path.Combine(editorFolderPath, "Resources");
-                if (!Directory.Exists(resourcesFolderPath))
-                {
-                    AssetDatabase.CreateFolder(editorFolderPath, "Resources");
-                }
-
-                // Ensure the settings path exists within the Resources folder.
-                string settingsFolderPath = Path.Combine(resourcesFolderPath, UniversalSDKSettings.settingsPath);
-                if (!Directory.Exists(settingsFolderPath))
-                {
-                    AssetDatabase.CreateFolder(resourcesFolderPath, UniversalSDKSettings.settingsPath);
-                }
-
-                // Create a new settings asset.
                 instance = ScriptableObject.CreateInstance<UniversalSDKSettings>();
                 AssetDatabase.CreateAsset(instance, fullPath);
                 AssetDatabase.SaveAssets();

--- a/Assets/UniversalSDK/Editor/UniversalSDKSettingsEditor.cs
+++ b/Assets/UniversalSDK/Editor/UniversalSDKSettingsEditor.cs
@@ -20,28 +20,46 @@ namespace Universal.UniversalSDK.Editor
         GUIContent devBuildLabel = new GUIContent("Dev Build [?]:", "Run app with extended debugging");
 
         const string UnityAssetFolder = "Assets";
-
+        
         public static UniversalSDKSettings GetOrCreateSettingsAsset()
         {
-            string fullPath = Path.Combine(Path.Combine(UnityAssetFolder, UniversalSDKSettings.settingsPath),
-                                           UniversalSDKSettings.settingsAssetName + UniversalSDKSettings.settingsAssetExtension);
+            // Construct the full path to the settings asset.
+            string fullPath = Path.Combine(UnityAssetFolder, "Editor", "Resources", UniversalSDKSettings.settingsPath, 
+                UniversalSDKSettings.settingsAssetName + UniversalSDKSettings.settingsAssetExtension);
 
-            UniversalSDKSettings instance = AssetDatabase.LoadAssetAtPath(fullPath, typeof(UniversalSDKSettings)) as UniversalSDKSettings;
+            // Try to load the settings asset.
+            UniversalSDKSettings instance = AssetDatabase.LoadAssetAtPath<UniversalSDKSettings>(fullPath);
 
+            // If the asset doesn't exist, create it.
             if (instance == null)
             {
-                if (!Directory.Exists(Path.Combine(UnityAssetFolder, "Editor")))
+                // Ensure the Editor folder exists.
+                string editorFolderPath = Path.Combine(UnityAssetFolder, "Editor");
+                if (!Directory.Exists(editorFolderPath))
                 {
                     AssetDatabase.CreateFolder(UnityAssetFolder, "Editor");
-                    if (!Directory.Exists(Path.Combine(UnityAssetFolder, UniversalSDKSettings.settingsPath)))
-                    {
-                        AssetDatabase.CreateFolder(Path.Combine(UnityAssetFolder, "Editor"), "UniversalSDK");
-                    }                    
-                }                
-                instance = CreateInstance<UniversalSDKSettings>();
+                }
+
+                // Ensure the Resources folder exists within the Editor folder.
+                string resourcesFolderPath = Path.Combine(editorFolderPath, "Resources");
+                if (!Directory.Exists(resourcesFolderPath))
+                {
+                    AssetDatabase.CreateFolder(editorFolderPath, "Resources");
+                }
+
+                // Ensure the settings path exists within the Resources folder.
+                string settingsFolderPath = Path.Combine(resourcesFolderPath, UniversalSDKSettings.settingsPath);
+                if (!Directory.Exists(settingsFolderPath))
+                {
+                    AssetDatabase.CreateFolder(resourcesFolderPath, UniversalSDKSettings.settingsPath);
+                }
+
+                // Create a new settings asset.
+                instance = ScriptableObject.CreateInstance<UniversalSDKSettings>();
                 AssetDatabase.CreateAsset(instance, fullPath);
                 AssetDatabase.SaveAssets();
             }
+
             return instance;
         }
 

--- a/Assets/UniversalSDK/Scripts/UniversalSDKSettings.cs
+++ b/Assets/UniversalSDK/Scripts/UniversalSDKSettings.cs
@@ -6,7 +6,7 @@ namespace Universal.UniversalSDK
     public class UniversalSDKSettings : ScriptableObject
     {
         public const string settingsAssetName = "UniversalSDKSettings";
-        public const string settingsPath = "Editor/UniversalSDK";
+        public const string settingsPath = "Editor/Resources/UniversalSDK";
         public const string settingsAssetExtension = ".asset";
         public const string sdkVersion = "1.2.6";
 

--- a/Assets/UniversalSDK/Scripts/UniversalSDKSettings.cs
+++ b/Assets/UniversalSDK/Scripts/UniversalSDKSettings.cs
@@ -6,7 +6,7 @@ namespace Universal.UniversalSDK
     public class UniversalSDKSettings : ScriptableObject
     {
         public const string settingsAssetName = "UniversalSDKSettings";
-        public const string settingsPath = "Editor/Resources/UniversalSDK";
+        public const string settingsPath = "Editor/UniversalSDK/Resources";
         public const string settingsAssetExtension = ".asset";
         public const string sdkVersion = "1.2.6";
 


### PR DESCRIPTION
## Problem Description

When building sometimes the .plist file was missing the Universal SDK properties. The root of the problem is in **UniversalSDKSettings.cs** because this property is used by **PlistUpdating.cs**:

```cs
public static UniversalSDKSettings Instance
{
    get
    {
        if (ReferenceEquals(instance, null))
        {
            // this can not find the settings object in the Assets/Editor/UniversalSDK folder
            instance = Resources.Load(settingsAssetName) as UniversalSDKSettings;
            if (ReferenceEquals(instance, null))
            {
                // as a fallback here a temporary object is created
                instance = CreateInstance<UniversalSDKSettings>();
            }
        }
        return instance;
    }
}
```


Why does it sometimes work? Because opening the settings object in the inspector updates the temporary instance in **UniversalSDKSettingsEditor.cs**:

```cs
string fullPath = Path.Combine(Path.Combine(UnityAssetFolder, UniversalSDKSettings.settingsPath), UniversalSDKSettings.settingsAssetName + UniversalSDKSettings.settingsAssetExtension);
UniversalSDKSettings instance = AssetDatabase.LoadAssetAtPath(fullPath, typeof(UniversalSDKSettings)) as UniversalSDKSettings;
```


## Fix Description

Moving the Settings from **Assets/Editor/UniversalSDK** to **Assets/Editor/UniversalSDK/Resources** fixes the problem. Now **Resources.Load()** can find the settings asset.

Also the folder creation got a slight rework which is still not ideal but a bit more robust I think.